### PR TITLE
Add ScaleFont::glyph_bounds

### DIFF
--- a/dev/examples/ascii.rs
+++ b/dev/examples/ascii.rs
@@ -51,7 +51,7 @@ fn draw_ascii<F: Font>(font: F) {
     let mut pixel_data = vec![0.0; px_width * px_height];
     for g in glyphs {
         if let Some(og) = scaled_font.outline_glyph(g) {
-            let bounds = og.bounds();
+            let bounds = og.px_bounds();
             og.draw(|x, y, v| {
                 let x = x as f32 + bounds.min.x;
                 let y = y as f32 + bounds.min.y;

--- a/dev/examples/image.rs
+++ b/dev/examples/image.rs
@@ -48,7 +48,7 @@ fn draw_image<F: Font>(font: F) {
     // Loop through the glyphs in the text, positing each one on a line
     for glyph in glyphs {
         if let Some(outlined) = scaled_font.outline_glyph(glyph) {
-            let bounds = outlined.bounds();
+            let bounds = outlined.px_bounds();
             // Draw the glyph into the image per-pixel by using the draw closure
             outlined.draw(|x, y, v| {
                 // Offset the position by the glyph bounding box

--- a/dev/tests/render_reference.rs
+++ b/dev/tests/render_reference.rs
@@ -122,7 +122,7 @@ fn outline_draw<F: Font>(font: F, c: char, scale: f32) -> image::GrayAlphaImage 
     let font = font.into_scaled(scale);
 
     let glyph = font.outline_glyph(font.scaled_glyph(c)).unwrap();
-    let bounds = glyph.bounds();
+    let bounds = glyph.px_bounds();
 
     let mut glyph_image =
         DynamicImage::new_luma_a8(bounds.width() as _, bounds.height() as _).to_luma_alpha();

--- a/glyph/CHANGELOG.md
+++ b/glyph/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+* Add `ScaleFont::glyph_bounds` method, similar to glyph_brush's `glyph_bounds` but for a single glyph.
+* Rename `OutlinedGlyph::bounds` to `OutlinedGlyph::px_bounds` for clarity.
+
 # 0.2.1
 * Update _ttf-parser_ to `0.6`.
 

--- a/glyph/src/outlined.rs
+++ b/glyph/src/outlined.rs
@@ -70,9 +70,15 @@ impl OutlinedGlyph {
         &self.glyph
     }
 
+    #[deprecated = "Renamed to `px_bounds`"]
+    #[doc(hidden)]
+    pub fn bounds(&self) -> Rect {
+        self.px_bounds()
+    }
+
     /// Conservative whole number pixel bounding box for this glyph.
     #[inline]
-    pub fn bounds(&self) -> Rect {
+    pub fn px_bounds(&self) -> Rect {
         self.px_bounds
     }
 

--- a/glyph/src/scale.rs
+++ b/glyph/src/scale.rs
@@ -1,4 +1,4 @@
-use crate::{Font, Glyph, GlyphId, OutlinedGlyph};
+use crate::{point, Font, Glyph, GlyphId, OutlinedGlyph, Rect};
 
 /// Pixel scale.
 ///
@@ -148,6 +148,19 @@ pub trait ScaleFont<F: Font> {
     #[inline]
     fn kern(&self, first: GlyphId, second: GlyphId) -> f32 {
         self.h_scale_factor() * self.font().kern_unscaled(first, second)
+    }
+
+    /// Returns the layout bounds of this glyph. These are different to the outline `px_bounds()`.
+    ///
+    /// Horizontally: Glyph position +/- h_advance/h_side_bearing.
+    /// Vertically: Glyph position +/- ascent/descent.
+    #[inline]
+    fn glyph_bounds(&self, glyph: &Glyph) -> Rect {
+        let pos = glyph.position;
+        Rect {
+            min: point(pos.x - self.h_side_bearing(glyph.id), pos.y - self.ascent()),
+            max: point(pos.x + self.h_advance(glyph.id), pos.y - self.descent()),
+        }
     }
 
     /// The number of glyphs present in this font. Glyph identifiers for this


### PR DESCRIPTION
* Add `ScaleFont::glyph_bounds` method, similar to glyph_brush's `glyph_bounds` but for a single glyph.
* Rename `OutlinedGlyph::bounds` to `OutlinedGlyph::px_bounds` for clarity.