### PR TITLE
Add Font::units_per_em, derived methods and doc

### DIFF
--- a/glyph/src/font_arc.rs
+++ b/glyph/src/font_arc.rs
@@ -72,6 +72,11 @@ impl fmt::Debug for FontArc {
 
 impl Font for FontArc {
     #[inline]
+    fn units_per_em(&self) -> Option<f32> {
+        self.0.units_per_em()
+    }
+
+    #[inline]
     fn ascent_unscaled(&self) -> f32 {
         self.0.ascent_unscaled()
     }

--- a/glyph/src/scale.rs
+++ b/glyph/src/scale.rs
@@ -2,6 +2,11 @@ use crate::{Font, Glyph, GlyphId, OutlinedGlyph, Rect};
 
 /// Pixel scale.
 ///
+/// This is the pixel-height of text.
+///
+/// Usually one uses `x == y`, but one may use a different ratio to stretch a
+/// font horizontally or vertically.
+///
 /// # Example
 /// ```
 /// use ab_glyph::PxScale;
@@ -13,6 +18,8 @@ pub struct PxScale {
     /// Horizontal scale in pixels.
     pub x: f32,
     /// Vertical scale in pixels.
+    ///
+    /// By definition, this is the pixel-height of a font.
     pub y: f32,
 }
 
@@ -94,6 +101,8 @@ pub trait ScaleFont<F: Font> {
     }
 
     /// Pixel scaled height `ascent - descent`.
+    ///
+    /// By definition of [`PxScale`], this is `self.scale().y`.
     #[inline]
     fn height(&self) -> f32 {
         self.scale().y

--- a/glyph/src/ttfp.rs
+++ b/glyph/src/ttfp.rs
@@ -146,6 +146,11 @@ macro_rules! impl_font {
     ($font:ty) => {
         impl Font for $font {
             #[inline]
+            fn units_per_em(&self) -> Option<f32> {
+                self.0.as_face_ref().units_per_em().map(|u| f32::from(u))
+            }
+
+            #[inline]
             fn ascent_unscaled(&self) -> f32 {
                 f32::from(self.0.as_face_ref().ascender())
             }


### PR DESCRIPTION
This partly follows on from #6 which was closed without specifying a unit. In https://github.com/kas-gui/kas-text/pull/7 @RazrFalcon explained that `ttf-parser` is just using font-units for everything, which means to know what the unit is we need [`Face::units_per_em`](https://docs.rs/ttf-parser/0.7.0/ttf_parser/struct.Face.html#method.units_per_em). This adds that, plus some derived methods and clarifying documentation.

For my purposes, I generate the raw scale factors directly (and then multiply by `font.height_unscaled()` for compatibility with `PxScale`). Therefore an extension to this PR could be to add `RawScale` and `RawScaleFont` types, with the latter implementing `ScaleFont`. Caveat: `Glyph::scale` has type `PxScale`, thus it would be necessary to convert `RawScale` to `PxScale` anyway for drawing (unless `Glyph` is generalised, which would be significantly more work).