### PR TITLE
impl Font for ttf_parser::Face

### DIFF
--- a/glyph/src/font_arc.rs
+++ b/glyph/src/font_arc.rs
@@ -60,7 +60,8 @@ impl FontArc {
     /// ```
     #[inline]
     pub fn try_from_slice(data: &'static [u8]) -> Result<Self, InvalidFont> {
-        Ok(FontRef::try_from_slice(data)?.into())
+        let font = owned_ttf_parser::Face::from_slice(data, 0).map_err(|_| InvalidFont)?;
+        Ok(font.into())
     }
 }
 
@@ -141,6 +142,12 @@ impl From<FontVec> for FontArc {
 impl From<FontRef<'static>> for FontArc {
     #[inline]
     fn from(font: FontRef<'static>) -> Self {
+        Self::new(font)
+    }
+}
+impl From<owned_ttf_parser::Face<'static>> for FontArc {
+    #[inline]
+    fn from(font: owned_ttf_parser::Face<'static>) -> Self {
         Self::new(font)
     }
 }

--- a/glyph/src/font_arc.rs
+++ b/glyph/src/font_arc.rs
@@ -49,6 +49,24 @@ impl FontArc {
         Ok(FontVec::try_from_vec(data)?.into())
     }
 
+    /// Creates an `FontArc` from owned data.
+    ///
+    /// You can set index for font collections. For simple fonts use `0` or
+    /// [`FontArc::try_from_vec`](#method.try_from_vec).
+    ///
+    /// # Example
+    /// ```
+    /// # use ab_glyph::*;
+    /// # fn main() -> Result<(), InvalidFont> {
+    /// # let owned_font_data = include_bytes!("../../dev/fonts/Exo2-Light.otf").to_vec();
+    /// let font = FontArc::try_from_vec_and_index(owned_font_data, 0)?;
+    /// # Ok(()) }
+    /// ```
+    #[inline]
+    pub fn try_from_vec_and_index(data: Vec<u8>, index: u32) -> Result<Self, InvalidFont> {
+        Ok(FontVec::try_from_vec_and_index(data, index)?.into())
+    }
+
     /// Creates an `FontArc` from a byte-slice.
     ///
     /// # Example
@@ -61,6 +79,25 @@ impl FontArc {
     #[inline]
     pub fn try_from_slice(data: &'static [u8]) -> Result<Self, InvalidFont> {
         let font = owned_ttf_parser::Face::from_slice(data, 0).map_err(|_| InvalidFont)?;
+        Ok(font.into())
+    }
+
+    /// Creates an `FontArc` from byte-slice.
+    ///
+    /// You can set index for font collections. For simple fonts use `0` or
+    /// [`FontArc::try_from_slice`](#method.try_from_slice).
+    ///
+    /// # Example
+    /// ```
+    /// # use ab_glyph::*;
+    /// # fn main() -> Result<(), InvalidFont> {
+    /// let font =
+    ///     FontArc::try_from_slice_and_index(include_bytes!("../../dev/fonts/Exo2-Light.otf"), 0)?;
+    /// # Ok(()) }
+    /// ```
+    #[inline]
+    pub fn try_from_slice_and_index(data: &'static [u8], index: u32) -> Result<Self, InvalidFont> {
+        let font = owned_ttf_parser::Face::from_slice(data, index).map_err(|_| InvalidFont)?;
         Ok(font.into())
     }
 }

--- a/glyph/src/ttfp.rs
+++ b/glyph/src/ttfp.rs
@@ -38,6 +38,13 @@ impl fmt::Debug for FontRef<'_> {
     }
 }
 
+impl<'font> owned_ttf_parser::AsFaceRef for FontRef<'font> {
+    #[inline]
+    fn as_face_ref(&self) -> &owned_ttf_parser::Face<'_> {
+        self.0.as_face_ref()
+    }
+}
+
 impl<'font> FontRef<'font> {
     /// Creates an `FontRef` from a byte-slice.
     ///
@@ -101,6 +108,13 @@ impl fmt::Debug for FontVec {
     }
 }
 
+impl owned_ttf_parser::AsFaceRef for FontVec {
+    #[inline]
+    fn as_face_ref(&self) -> &owned_ttf_parser::Face<'_> {
+        self.0.as_face_ref()
+    }
+}
+
 impl FontVec {
     /// Creates an `FontVec` from owned data.
     ///
@@ -147,28 +161,27 @@ macro_rules! impl_font {
         impl Font for $font {
             #[inline]
             fn units_per_em(&self) -> Option<f32> {
-                self.0.as_face_ref().units_per_em().map(f32::from)
+                self.as_face_ref().units_per_em().map(f32::from)
             }
 
             #[inline]
             fn ascent_unscaled(&self) -> f32 {
-                f32::from(self.0.as_face_ref().ascender())
+                f32::from(self.as_face_ref().ascender())
             }
 
             #[inline]
             fn descent_unscaled(&self) -> f32 {
-                f32::from(self.0.as_face_ref().descender())
+                f32::from(self.as_face_ref().descender())
             }
 
             #[inline]
             fn line_gap_unscaled(&self) -> f32 {
-                f32::from(self.0.as_face_ref().line_gap())
+                f32::from(self.as_face_ref().line_gap())
             }
 
             #[inline]
             fn glyph_id(&self, c: char) -> GlyphId {
                 let index = self
-                    .0
                     .as_face_ref()
                     .glyph_index(c)
                     .map(|id| id.0)
@@ -179,7 +192,6 @@ macro_rules! impl_font {
             #[inline]
             fn h_advance_unscaled(&self, id: GlyphId) -> f32 {
                 let advance = self
-                    .0
                     .as_face_ref()
                     .glyph_hor_advance(id.into())
                     .expect("Invalid glyph_hor_advance");
@@ -189,7 +201,6 @@ macro_rules! impl_font {
             #[inline]
             fn h_side_bearing_unscaled(&self, id: GlyphId) -> f32 {
                 let advance = self
-                    .0
                     .as_face_ref()
                     .glyph_hor_side_bearing(id.into())
                     .expect("Invalid glyph_hor_side_bearing");
@@ -199,7 +210,6 @@ macro_rules! impl_font {
             #[inline]
             fn v_advance_unscaled(&self, id: GlyphId) -> f32 {
                 let advance = self
-                    .0
                     .as_face_ref()
                     .glyph_ver_advance(id.into())
                     .expect("Invalid glyph_ver_advance");
@@ -209,7 +219,6 @@ macro_rules! impl_font {
             #[inline]
             fn v_side_bearing_unscaled(&self, id: GlyphId) -> f32 {
                 let advance = self
-                    .0
                     .as_face_ref()
                     .glyph_ver_side_bearing(id.into())
                     .expect("Invalid glyph_ver_side_bearing");
@@ -218,8 +227,7 @@ macro_rules! impl_font {
 
             #[inline]
             fn kern_unscaled(&self, first: GlyphId, second: GlyphId) -> f32 {
-                self.0
-                    .as_face_ref()
+                self.as_face_ref()
                     .kerning_subtables()
                     .filter(|st| st.is_horizontal() && !st.is_variable())
                     .find_map(|st| st.glyphs_kerning(first.into(), second.into()))
@@ -235,10 +243,7 @@ macro_rules! impl_font {
                     y_min,
                     x_max,
                     y_max,
-                } = self
-                    .0
-                    .as_face_ref()
-                    .outline_glyph(id.into(), &mut outliner)?;
+                } = self.as_face_ref().outline_glyph(id.into(), &mut outliner)?;
 
                 let bounds = Rect {
                     min: point(x_min as f32, y_max as f32),
@@ -253,7 +258,7 @@ macro_rules! impl_font {
 
             #[inline]
             fn glyph_count(&self) -> usize {
-                self.0.as_face_ref().number_of_glyphs() as _
+                self.as_face_ref().number_of_glyphs() as _
             }
         }
     };

--- a/glyph/src/ttfp.rs
+++ b/glyph/src/ttfp.rs
@@ -45,6 +45,13 @@ impl<'font> owned_ttf_parser::AsFaceRef for FontRef<'font> {
     }
 }
 
+impl<'font> From<owned_ttf_parser::Face<'font>> for FontRef<'font> {
+    #[inline]
+    fn from(font: owned_ttf_parser::Face<'font>) -> Self {
+        FontRef(font)
+    }
+}
+
 impl<'font> FontRef<'font> {
     /// Creates an `FontRef` from a byte-slice.
     ///
@@ -266,3 +273,4 @@ macro_rules! impl_font {
 
 impl_font!(FontRef<'_>);
 impl_font!(FontVec);
+impl_font!(owned_ttf_parser::Face<'_>);


### PR DESCRIPTION
This exposes `ttf_parser::Face` in the API which you *may* not want to do, but IMO this would be quite useful. (In my case, I would likely use `GlyphBrush<F = &'static ttf_parser::Face>`, allowing me to still access the `Face` directly, along with its many [methods](https://docs.rs/ttf-parser/0.8.2/ttf_parser/struct.Face.html).)

One could instead add more methods into `Font`, but I'm not sure it's worthwhile. The next ones I want are `underline_metrics` and `strikeout_metrics`, but there will likely be more in the future.

Of course this does somewhat tie `ab-glyph` to `ttf_parser`.