### PR TITLE
Add Font::codepoint_ids

### DIFF
--- a/glyph/CHANGELOG.md
+++ b/glyph/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* Add `Font::codepoint_ids` method for iterating over `(GlyphId, char)` pairs.
 * Clarify documentation.
 
 # 0.2.5

--- a/glyph/src/codepoint_ids.rs
+++ b/glyph/src/codepoint_ids.rs
@@ -1,0 +1,24 @@
+use crate::GlyphId;
+use alloc::boxed::Box;
+use core::{fmt, iter};
+
+pub struct CodepointIdIter<'a> {
+    pub(crate) inner: Box<dyn Iterator<Item = (GlyphId, char)> + 'a>,
+}
+
+impl<'a> Iterator for CodepointIdIter<'a> {
+    type Item = (GlyphId, char);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+impl iter::FusedIterator for CodepointIdIter<'_> {}
+
+impl fmt::Debug for CodepointIdIter<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CodepointIdIter")
+    }
+}

--- a/glyph/src/font.rs
+++ b/glyph/src/font.rs
@@ -105,6 +105,29 @@ pub trait Font {
     /// font will always be in the range `0..self.glyph_count()`
     fn glyph_count(&self) -> usize;
 
+    /// Returns an iterator of all distinct `(GlyphId, char)` pairs. Not ordered.
+    ///
+    /// # Example
+    /// ```
+    /// # use ab_glyph::{Font, FontRef, GlyphId};
+    /// # use std::collections::HashMap;
+    /// # fn main() -> Result<(), ab_glyph::InvalidFont> {
+    /// let font = FontRef::try_from_slice(include_bytes!("../../dev/fonts/Exo2-Light.otf"))?;
+    ///
+    /// // Iterate over pairs, each id will appear at most once.
+    /// let mut codepoint_ids = font.codepoint_ids();
+    /// assert_eq!(codepoint_ids.next(), Some((GlyphId(408), '\r')));
+    /// assert_eq!(codepoint_ids.next(), Some((GlyphId(1), ' ')));
+    /// assert_eq!(codepoint_ids.next(), Some((GlyphId(75), '!')));
+    ///
+    /// // Build a lookup map for all ids
+    /// let map: HashMap<_, _> = font.codepoint_ids().collect();
+    /// assert_eq!(map.get(&GlyphId(75)), Some(&'!'));
+    /// # assert_eq!(map.len(), 908);
+    /// # Ok(()) }
+    /// ```
+    fn codepoint_ids(&self) -> crate::CodepointIdIter<'_>;
+
     /// Returns the layout bounds of this glyph. These are different to the outline `px_bounds()`.
     ///
     /// Horizontally: Glyph position +/- h_advance/h_side_bearing.
@@ -232,5 +255,10 @@ impl<F: Font> Font for &F {
     #[inline]
     fn glyph_count(&self) -> usize {
         (*self).glyph_count()
+    }
+
+    #[inline]
+    fn codepoint_ids(&self) -> crate::CodepointIdIter<'_> {
+        (*self).codepoint_ids()
     }
 }

--- a/glyph/src/font_arc.rs
+++ b/glyph/src/font_arc.rs
@@ -130,6 +130,11 @@ impl Font for FontArc {
     fn glyph_count(&self) -> usize {
         self.0.glyph_count()
     }
+
+    #[inline]
+    fn codepoint_ids(&self) -> crate::CodepointIdIter<'_> {
+        self.0.codepoint_ids()
+    }
 }
 
 impl From<FontVec> for FontArc {

--- a/glyph/src/lib.rs
+++ b/glyph/src/lib.rs
@@ -21,6 +21,7 @@
 
 extern crate alloc;
 
+mod codepoint_ids;
 mod err;
 mod font;
 #[cfg(feature = "std")]
@@ -35,6 +36,7 @@ mod ttfp;
 #[cfg(feature = "std")]
 pub use crate::font_arc::*;
 pub use crate::{
+    codepoint_ids::*,
     err::*,
     font::*,
     glyph::*,

--- a/glyph/src/scale.rs
+++ b/glyph/src/scale.rs
@@ -190,6 +190,11 @@ pub trait ScaleFont<F: Font> {
         self.font().glyph_count()
     }
 
+    /// Returns an iterator of all distinct `(GlyphId, char)` pairs. Not ordered.
+    ///
+    /// Same as [`Font::codepoint_ids`](trait.Font.html#tymethod.codepoint_ids).
+    fn codepoint_ids(&self) -> crate::CodepointIdIter<'_>;
+
     /// Compute glyph outline ready for drawing.
     ///
     /// Note this method does not make use of the associated scale, as `Glyph`
@@ -209,6 +214,11 @@ impl<F: Font, SF: ScaleFont<F>> ScaleFont<F> for &SF {
     #[inline]
     fn font(&self) -> &F {
         (*self).font()
+    }
+
+    #[inline]
+    fn codepoint_ids(&self) -> crate::CodepointIdIter<'_> {
+        (*self).codepoint_ids()
     }
 }
 
@@ -236,5 +246,10 @@ impl<F: Font> ScaleFont<F> for PxScaleFont<F> {
     #[inline]
     fn font(&self) -> &F {
         &self.font
+    }
+
+    #[inline]
+    fn codepoint_ids(&self) -> crate::CodepointIdIter<'_> {
+        self.font.codepoint_ids()
     }
 }


### PR DESCRIPTION
Provide an abstraction for mapping `GlyphId` -> `char`.

```rust
pub trait Font {
    fn codepoint_ids(&self) -> crate::CodepointIdIter<'_>;
}
```

```rust
let font = FontRef::try_from_slice(include_bytes!("../../dev/fonts/Exo2-Light.otf"))?;

// Iterate over pairs, each id will appear at most once.
let mut codepoint_ids = font.codepoint_ids();
assert_eq!(codepoint_ids.next(), Some((GlyphId(408), '\r')));
assert_eq!(codepoint_ids.next(), Some((GlyphId(1), ' ')));
assert_eq!(codepoint_ids.next(), Some((GlyphId(75), '!')));

// Build a lookup map for all ids
let map: HashMap<_, _> = font.codepoint_ids().collect();
assert_eq!(map.get(&GlyphId(75)), Some(&'!'));
```

Resolves #18