### PR TITLE
Add OutlinedGlyph::draw_using

### DIFF
--- a/glyph/CHANGELOG.md
+++ b/glyph/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-* Add `OutlinedGlyph::draw_using` allowing reusing of `Rasterizer` allocation.
+* Add `OutlinedGlyph::draw_using` allowing reuse of `Rasterizer` allocation.
 * Update _ttf-parser_ to `0.10`.
 
 # 0.2.7

--- a/glyph/CHANGELOG.md
+++ b/glyph/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* Add `OutlinedGlyph::draw_using` allowing reusing of `Rasterizer` allocation.
 * Update _ttf-parser_ to `0.10`.
 
 # 0.2.7

--- a/glyph/src/glyph.rs
+++ b/glyph/src/glyph.rs
@@ -1,8 +1,4 @@
-use crate::PxScale;
-
-/// An (x, y) coordinate. `Point { x: f32, y: f32 }`
-pub type Point = ab_glyph_rasterizer::Point;
-pub use ab_glyph_rasterizer::point;
+use crate::{Point, PxScale};
 
 /// Glyph id.
 ///

--- a/glyph/src/lib.rs
+++ b/glyph/src/lib.rs
@@ -44,3 +44,4 @@ pub use crate::{
     scale::*,
     ttfp::{FontRef, FontVec},
 };
+pub use ab_glyph_rasterizer::{point, Point, Rasterizer};

--- a/glyph/src/outlined.rs
+++ b/glyph/src/outlined.rs
@@ -50,8 +50,7 @@ pub struct OutlinedGlyph {
 }
 
 impl OutlinedGlyph {
-    /// Constructs an `OutlinedGlyph` from the source `Glyph`, pixel bounds
-    /// & relatively positioned outline curves.
+    /// Constructs from a glyph, relatively positioned outline curves & scale-factor.
     #[inline]
     pub fn new(glyph: Glyph, outline: Outline, scale_factor: PxScaleFactor) -> Self {
         // work this out now as it'll usually be used more than once


### PR DESCRIPTION
Add `OutlinedGlyph::draw_using` allowing reuse of `Rasterizer` allocation.

However, in my early tests it doesn't look like reusing a `Rasterizer` actually improves real-world performance. Without a use-case this probably isn't worth merging.