### PR TITLE
Add as_ttf_face to Font, exposing the ttf_parser interfaces

### DIFF
--- a/glyph/src/font.rs
+++ b/glyph/src/font.rs
@@ -128,6 +128,10 @@ pub trait Font {
     /// ```
     fn codepoint_ids(&self) -> crate::CodepointIdIter<'_>;
 
+    /// Returns the underlying ttf_parser::Face which can be used to access properties of the font
+    /// not directly exposed by this library (glyph names, raster images for emoji, kerning, etc).
+    fn as_ttf_face(&self) -> &owned_ttf_parser::Face<'_>;
+
     /// Returns the layout bounds of this glyph. These are different to the outline `px_bounds()`.
     ///
     /// Horizontally: Glyph position +/- h_advance/h_side_bearing.
@@ -260,5 +264,10 @@ impl<F: Font> Font for &F {
     #[inline]
     fn codepoint_ids(&self) -> crate::CodepointIdIter<'_> {
         (*self).codepoint_ids()
+    }
+
+    #[inline]
+    fn as_ttf_face(&self) -> &owned_ttf_parser::Face<'_> {
+        (*self).as_ttf_face()
     }
 }

--- a/glyph/src/font_arc.rs
+++ b/glyph/src/font_arc.rs
@@ -135,6 +135,10 @@ impl Font for FontArc {
     fn codepoint_ids(&self) -> crate::CodepointIdIter<'_> {
         self.0.codepoint_ids()
     }
+
+    fn as_ttf_face(&self) -> &owned_ttf_parser::Face<'_> {
+        self.0.as_ttf_face()
+    }
 }
 
 impl From<FontVec> for FontArc {

--- a/glyph/src/ttfp.rs
+++ b/glyph/src/ttfp.rs
@@ -291,6 +291,10 @@ macro_rules! impl_font {
 
                 crate::CodepointIdIter { inner }
             }
+
+            fn as_ttf_face(&self) -> &owned_ttf_parser::Face<'_> {
+                self.0.as_face_ref()
+            }
         }
     };
 }


### PR DESCRIPTION
This allows using ttf_parser's more advanced APIs without needing to
parse the font twice.