### PR TITLE
Add `Font::pt_to_px_scale`, `PxScale::round`

### DIFF
--- a/glyph/CHANGELOG.md
+++ b/glyph/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased (v0.2.16)
+* Add `Font::pt_to_px_scale` to ease converting point size to `PxScale`.
+* Add `PxScale::round`.
+
 # v0.2.15
 * Fix some font outlines by always trying to "close" them at the end. Fixes _Cantarell-VF.otf_ outlining.
 

--- a/glyph/src/scale.rs
+++ b/glyph/src/scale.rs
@@ -1,3 +1,5 @@
+#[cfg(all(feature = "libm", not(feature = "std")))]
+use crate::nostd_float::FloatExt;
 use crate::{Font, Glyph, GlyphId, OutlinedGlyph, Rect};
 
 /// Pixel scale.
@@ -6,6 +8,8 @@ use crate::{Font, Glyph, GlyphId, OutlinedGlyph, Rect};
 ///
 /// Usually one uses `x == y`, but one may use a different ratio to stretch a
 /// font horizontally or vertically.
+/// 
+/// To convert pt size into pixel-scale see [`Font::pt_to_px_scale`].
 ///
 /// # Example
 /// ```
@@ -21,6 +25,17 @@ pub struct PxScale {
     ///
     /// By definition, this is the pixel-height of a font.
     pub y: f32,
+}
+
+impl PxScale {
+    /// Returns a `PxScale` with both x & y scale values set to the nearest integer.
+    #[inline]
+    pub fn round(self) -> Self {
+        Self {
+            x: self.x.round(),
+            y: self.y.round(),
+        }
+    }
 }
 
 impl From<f32> for PxScale {

--- a/glyph/src/ttfp.rs
+++ b/glyph/src/ttfp.rs
@@ -5,8 +5,7 @@ use crate::{point, Font, GlyphId, InvalidFont, Outline, Point, Rect};
 use alloc::boxed::Box;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-use core::convert::TryFrom;
-use core::fmt;
+use core::{convert::TryFrom, fmt};
 use owned_ttf_parser::{self as ttfp, AsFaceRef};
 
 impl From<GlyphId> for ttfp::GlyphId {


### PR DESCRIPTION
Make life a little easier when using pt glyph sizes.