### PR TITLE
Add runtime detected AVX2 or SSE4.2 line drawing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,18 @@ jobs:
     steps:
     - run: rustup update stable
     - run: rustup target add thumbv6m-none-eabi
+    - run: rustup target add wasm32-unknown-unknown
     - uses: actions/checkout@v2
     - run: cargo test
     - run: cargo test --benches
     - name: Build no_std ab_glyph_rasterizer
-      run: (cd rasterizer && cargo build --target thumbv6m-none-eabi --no-default-features --features libm)
+      run: cargo build -p ab_glyph_rasterizer --target thumbv6m-none-eabi --no-default-features --features libm
     - name: Build no_std ab_glyph
-      run: (cd glyph && cargo build --target thumbv6m-none-eabi --no-default-features --features libm)
+      run: cargo build -p ab_glyph --target thumbv6m-none-eabi --no-default-features --features libm
+    - name: Build wasm32 ab_glyph_rasterizer
+      run: cargo build -p ab_glyph_rasterizer --target wasm32-unknown-unknown
+    - name: Build wasm32 ab_glyph
+      run: cargo build -p ab_glyph --target wasm32-unknown-unknown
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test:

--- a/rasterizer/CHANGELOG.md
+++ b/rasterizer/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased (0.1.6)
-* Add runtime detected AVX2 or SSE4.2 line drawing.
+* Add runtime detected AVX2 or SSE4.2 line drawing. Improves performance on compatible x86_64 CPUs.
 
 # 0.1.5
 * Remove cap of `1.0` for coverage values returned by `for_each_pixel` now `>= 1.0` means fully covered.

--- a/rasterizer/CHANGELOG.md
+++ b/rasterizer/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased (0.1.6)
+* Add runtime detected AVX2 or SSE4.2 line drawing.
+
 # 0.1.5
 * Remove cap of `1.0` for coverage values returned by `for_each_pixel` now `>= 1.0` means fully covered.
   This allows a minor reduction in operations / performance boost.

--- a/rasterizer/src/raster.rs
+++ b/rasterizer/src/raster.rs
@@ -42,7 +42,7 @@ impl Rasterizer {
     /// ```
     pub fn new(width: usize, height: usize) -> Self {
         // runtime detect optimal simd impls
-        #[cfg(feature = "std")]
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         let draw_line_fn: DrawLineFn = if is_x86_feature_detected!("avx2") {
             draw_line_avx2
         } else if is_x86_feature_detected!("sse4.2") {
@@ -50,7 +50,7 @@ impl Rasterizer {
         } else {
             Self::draw_line_scalar
         };
-        #[cfg(not(feature = "std"))]
+        #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
         let draw_line_fn: DrawLineFn = Self::draw_line_scalar;
 
         Self {
@@ -308,13 +308,13 @@ impl core::fmt::Debug for Rasterizer {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx2")]
 unsafe fn draw_line_avx2(rast: &mut Rasterizer, p0: Point, p1: Point) {
     rast.draw_line_scalar(p0, p1)
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "sse4.2")]
 unsafe fn draw_line_sse4_2(rast: &mut Rasterizer, p0: Point, p1: Point) {
     rast.draw_line_scalar(p0, p1)

--- a/rasterizer/src/raster.rs
+++ b/rasterizer/src/raster.rs
@@ -23,11 +23,14 @@ use alloc::vec::Vec;
 
 use crate::geometry::{lerp, Point};
 
+type DrawLineFn = unsafe fn(&mut Rasterizer, Point, Point);
+
 /// Coverage rasterizer for lines, quadratic & cubic beziers.
 pub struct Rasterizer {
     width: usize,
     height: usize,
     a: Vec<f32>,
+    draw_line_fn: DrawLineFn,
 }
 
 impl Rasterizer {
@@ -38,10 +41,23 @@ impl Rasterizer {
     /// let mut rasterizer = Rasterizer::new(14, 38);
     /// ```
     pub fn new(width: usize, height: usize) -> Self {
+        // runtime detect optimal simd impls
+        #[cfg(feature = "std")]
+        let draw_line_fn: DrawLineFn = if is_x86_feature_detected!("avx2") {
+            draw_line_avx2
+        } else if is_x86_feature_detected!("sse4.2") {
+            draw_line_sse4_2
+        } else {
+            Self::draw_line_scalar
+        };
+        #[cfg(not(feature = "std"))]
+        let draw_line_fn: DrawLineFn = Self::draw_line_scalar;
+
         Self {
             width,
             height,
             a: vec![0.0; width * height + 4],
+            draw_line_fn,
         }
     }
 
@@ -95,6 +111,11 @@ impl Rasterizer {
     /// rasterizer.draw_line(point(0.0, 0.48), point(1.22, 0.48));
     /// ```
     pub fn draw_line(&mut self, p0: Point, p1: Point) {
+        unsafe { (self.draw_line_fn)(self, p0, p1) }
+    }
+
+    #[inline(always)] // must inline for simd versions
+    fn draw_line_scalar(&mut self, p0: Point, p1: Point) {
         if (p0.y - p1.y).abs() <= core::f32::EPSILON {
             return;
         }
@@ -285,4 +306,16 @@ impl core::fmt::Debug for Rasterizer {
             .field("height", &self.height)
             .finish()
     }
+}
+
+#[cfg(feature = "std")]
+#[target_feature(enable = "avx2")]
+unsafe fn draw_line_avx2(rast: &mut Rasterizer, p0: Point, p1: Point) {
+    rast.draw_line_scalar(p0, p1)
+}
+
+#[cfg(feature = "std")]
+#[target_feature(enable = "sse4.2")]
+unsafe fn draw_line_sse4_2(rast: &mut Rasterizer, p0: Point, p1: Point) {
+    rast.draw_line_scalar(p0, p1)
 }

--- a/test
+++ b/test
@@ -9,7 +9,10 @@ echo "==> test"
 cargo test
 cargo test --benches
 echo "==> no_std"
-(cd rasterizer && cargo build --target thumbv6m-none-eabi --no-default-features --features libm)
-(cd glyph && cargo build --target thumbv6m-none-eabi --no-default-features --features libm)
+cargo build -p ab_glyph_rasterizer --target thumbv6m-none-eabi --no-default-features --features libm
+cargo build -p ab_glyph --target thumbv6m-none-eabi --no-default-features --features libm
+echo "==> check wasm32"
+cargo build -p ab_glyph_rasterizer --target wasm32-unknown-unknown
+cargo build -p ab_glyph --target wasm32-unknown-unknown
 echo "==> rustfmt"
 cargo fmt -- --check


### PR DESCRIPTION
Add runtime detected AVX2 or SSE4.2 line drawing. This significantly improves rasterization performance on x86_64 CPUs.

## SSE4.2 benchmarks
According to the [steam survey](https://store.steampowered.com/hwsurvey/Steam-Hardware-Software-Survey-Welcome-to-Steam)  SSE4.2 has 98.83% cpu support coverage and provides a significant performance improvement.
```
group                              sse42                   main
-----                              -----                   ----
layout & draw (exo2-otf)           1.00    221.4±0.78µs    1.14    253.5±0.66µs
layout & draw (exo2-ttf)           1.00    236.1±0.16µs    1.18    278.8±0.19µs
rasterize_otf_tailed_e             1.00     20.2±0.24µs    1.04     21.0±0.01µs
rasterize_outline_ttf_biohazard    1.00     15.7±0.12µs    1.21     19.0±0.19µs
rasterize_outline_ttf_w            1.00    272.3±1.31ns    1.37    372.2±1.18ns
rasterize_ttf_biohazard            1.00     72.6±0.26µs    1.02     73.9±0.27µs
rasterize_ttf_tailed_e             1.00     18.5±0.05µs    1.08     20.0±0.05µs
rasterize_ttf_w                    1.00    311.8±2.14ns    1.37    427.0±1.56ns
```

## AVX2 benchmarks
AVX2 has 88.15% cpu support coverage. It provides better performance than SSE4.2.

```
group                              avx2                    main
-----                              ----                    ----
layout & draw (exo2-otf)           1.00    211.2±1.85µs    1.20    253.5±0.66µs
layout & draw (exo2-ttf)           1.00    233.6±0.31µs    1.19    278.8±0.19µs
rasterize_otf_tailed_e             1.00     20.1±0.03µs    1.05     21.0±0.01µs
rasterize_outline_ttf_biohazard    1.00     14.6±0.13µs    1.31     19.0±0.19µs
rasterize_outline_ttf_w            1.00    240.4±0.78ns    1.55    372.2±1.18ns
rasterize_ttf_biohazard            1.00     70.7±0.26µs    1.05     73.9±0.27µs
rasterize_ttf_tailed_e             1.00     18.4±0.03µs    1.09     20.0±0.05µs
rasterize_ttf_w                    1.00    294.1±1.21ns    1.45    427.0±1.56ns
```
```
group                              avx2                    sse42
-----                              ----                    -----
layout & draw (exo2-otf)           1.00    211.2±1.85µs    1.05    221.4±0.78µs
layout & draw (exo2-ttf)           1.00    233.6±0.31µs    1.01    236.1±0.16µs
rasterize_otf_tailed_e             1.00     20.1±0.03µs    1.00     20.2±0.24µs
rasterize_outline_ttf_biohazard    1.00     14.6±0.13µs    1.08     15.7±0.12µs
rasterize_outline_ttf_w            1.00    240.4±0.78ns    1.13    272.3±1.31ns
rasterize_ttf_biohazard            1.00     70.7±0.26µs    1.03     72.6±0.26µs
rasterize_ttf_tailed_e             1.00     18.4±0.03µs    1.01     18.5±0.05µs
rasterize_ttf_w                    1.00    294.1±1.21ns    1.06    311.8±2.14ns
```

## Other simd features
I did also test other feature levels (AVX, FMA, SSSE3). But having just SSE4.2 & AVX2 keeps things simpler for now & should provide speedups for the vast majority of x86_64 cases. More can be added if it makes sense.

## Auto-vectorize other functions
Currently just `draw_line` is runtime auto-vectorized. I tested `draw_quad` & `tesselate_cubic` but neither seemed affected (though they both rely on `draw_line` themselves so do benefit).