### PR TITLE
Add `VariableFont` to support reading & setting font variations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,2 @@
 [workspace]
 members = ["rasterizer", "glyph", "dev"]
-
-# TODO use release
-[patch.crates-io]
-owned_ttf_parser = { git = "https://github.com/alexheretic/owned-ttf-parser" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,6 @@
 [workspace]
 members = ["rasterizer", "glyph", "dev"]
+
+# TODO use release
+[patch.crates-io]
+owned_ttf_parser = { git = "https://github.com/alexheretic/owned-ttf-parser" }

--- a/glyph/CHANGELOG.md
+++ b/glyph/CHANGELOG.md
@@ -1,8 +1,13 @@
-# v0.2.16
+# Unreleased (0.2.17)
+* Add `VariableFont` trait implemented by `FontRef` & `FontVec`.
+  Provides `variations` & `set_variation` functions.
+* Add default enabled feature `variable-fonts`.
+
+# 0.2.16
 * Add `Font::pt_to_px_scale` to ease converting point size to `PxScale`.
 * Add `PxScale::round`.
 
-# v0.2.15
+# 0.2.15
 * Fix some font outlines by always trying to "close" them at the end. Fixes _Cantarell-VF.otf_ outlining.
 
 # 0.2.14

--- a/glyph/Cargo.toml
+++ b/glyph/Cargo.toml
@@ -20,8 +20,9 @@ libm2 = { package = "libm", version = "0.2.1", optional = true }
 # don't add any, instead use ./dev
 
 [features]
-default = ["std"]
+default = ["std", "variable-fonts"]
 # Activates usage of std.
 std = ["owned_ttf_parser/default", "ab_glyph_rasterizer/default"]
 # Uses libm when not using std. This needs to be active in that case.
 libm = ["libm2", "ab_glyph_rasterizer/libm"]
+variable-fonts = ["owned_ttf_parser/variable-fonts"]

--- a/glyph/Cargo.toml
+++ b/glyph/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-owned_ttf_parser = { version = "0.15", default-features = false }
+owned_ttf_parser = { version = "0.15.2", default-features = false }
 ab_glyph_rasterizer = { version = "0.1.2", path = "../rasterizer", default-features = false }
 # no_std float stuff
 # renamed to enable a "libm" feature

--- a/glyph/src/lib.rs
+++ b/glyph/src/lib.rs
@@ -32,6 +32,8 @@ mod nostd_float;
 mod outlined;
 mod scale;
 mod ttfp;
+#[cfg(feature = "variable-fonts")]
+mod variable;
 
 #[cfg(feature = "std")]
 pub use crate::font_arc::*;
@@ -44,3 +46,5 @@ pub use crate::{
     scale::*,
     ttfp::{FontRef, FontVec, GlyphImage, GlyphImageFormat},
 };
+#[cfg(feature = "variable-fonts")]
+pub use variable::*;

--- a/glyph/src/ttfp.rs
+++ b/glyph/src/ttfp.rs
@@ -1,5 +1,7 @@
 //! ttf-parser crate specific code. ttf-parser types should not be leaked publicly.
 mod outliner;
+#[cfg(feature = "variable-fonts")]
+mod variable;
 
 use crate::{point, Font, GlyphId, InvalidFont, Outline, Point, Rect};
 use alloc::boxed::Box;

--- a/glyph/src/ttfp/variable.rs
+++ b/glyph/src/ttfp/variable.rs
@@ -27,7 +27,6 @@ impl VariableFont for FontVec {
     }
 }
 
-#[inline]
 fn variations(face: &ttfp::Face<'_>) -> Vec<VariationAxis> {
     face.variation_axes()
         .into_iter()

--- a/glyph/src/ttfp/variable.rs
+++ b/glyph/src/ttfp/variable.rs
@@ -1,0 +1,55 @@
+use crate::{FontRef, FontVec, VariableFont, VariationAxis};
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+use owned_ttf_parser::{self as ttfp, AsFaceRef, FaceMut};
+
+impl VariableFont for FontRef<'_> {
+    fn set_variation(&mut self, axis: &[u8; 4], value: f32) -> bool {
+        self.0
+            .set_variation(ttfp::Tag::from_bytes(axis), value)
+            .is_some()
+    }
+
+    fn variations(&self) -> Vec<VariationAxis> {
+        variations(self.0.as_face_ref())
+    }
+}
+
+impl VariableFont for FontVec {
+    fn set_variation(&mut self, axis: &[u8; 4], value: f32) -> bool {
+        self.0
+            .set_variation(ttfp::Tag::from_bytes(axis), value)
+            .is_some()
+    }
+
+    fn variations(&self) -> Vec<VariationAxis> {
+        variations(self.0.as_face_ref())
+    }
+}
+
+#[inline]
+fn variations(face: &ttfp::Face<'_>) -> Vec<VariationAxis> {
+    face.variation_axes()
+        .into_iter()
+        .map(|axis| {
+            #[cfg(feature = "std")]
+            let name = face.names().into_iter().find_map(|n| {
+                if n.name_id == axis.name_id {
+                    n.to_string()
+                } else {
+                    None
+                }
+            });
+            #[cfg(not(feature = "std"))]
+            let name = None;
+            VariationAxis {
+                tag: axis.tag.to_bytes(),
+                name,
+                min_value: axis.min_value,
+                default_value: axis.def_value,
+                max_value: axis.max_value,
+                hidden: axis.hidden,
+            }
+        })
+        .collect()
+}

--- a/glyph/src/variable.rs
+++ b/glyph/src/variable.rs
@@ -1,0 +1,67 @@
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+/// Logic for variable fonts.
+///
+/// Requires feature `variable-fonts` (enabled by default).
+pub trait VariableFont {
+    /// Sets a variation axis coordinate value by it's tag.
+    ///
+    /// Returns false if there is no such axis tag.
+    ///
+    /// # Example
+    /// ```
+    /// use ab_glyph::{FontRef, VariableFont};
+    ///
+    /// # fn main() -> Result<(), ab_glyph::InvalidFont> {
+    /// let mut font = FontRef::try_from_slice(include_bytes!("../../dev/fonts/Cantarell-VF.otf"))?;
+    ///
+    /// // set weight to 600
+    /// assert!(font.set_variation(b"wght", 600.0));
+    ///
+    /// // no such variation tag "foob" so return false
+    /// assert!(!font.set_variation(b"foob", 200.0));
+    /// # Ok(()) }
+    /// ```
+    fn set_variation(&mut self, tag: &[u8; 4], value: f32) -> bool;
+
+    /// Returns variation axes.
+    ///
+    /// # Example
+    /// ```
+    /// use ab_glyph::{FontRef, VariableFont};
+    ///
+    /// # fn main() -> Result<(), ab_glyph::InvalidFont> {
+    /// let font = FontRef::try_from_slice(include_bytes!("../../dev/fonts/Cantarell-VF.otf"))?;
+    /// let var = &font.variations()[0];
+    /// # eprintln!("{var:#?}");
+    ///
+    /// assert_eq!(var.tag, *b"wght");
+    /// assert_eq!(var.name.as_deref(), Some("Weight"));
+    /// assert!((var.min_value - 100.0).abs() < f32::EPSILON);
+    /// assert!((var.default_value - 400.0).abs() < f32::EPSILON);
+    /// assert!((var.max_value - 800.0).abs() < f32::EPSILON);
+    /// assert!(!var.hidden);
+    /// # Ok(()) }
+    /// ```
+    fn variations(&self) -> Vec<VariationAxis>;
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct VariationAxis {
+    /// Tag identifying the design variation for the axis.
+    pub tag: [u8; 4],
+    /// Unicode name.
+    pub name: Option<String>,
+    /// The minimum coordinate value for the axis.
+    pub min_value: f32,
+    /// The default coordinate value for the axis.
+    pub default_value: f32,
+    /// The maximum coordinate value for the axis.
+    pub max_value: f32,
+    /// Whether the axis should be exposed directly in user interfaces.
+    pub hidden: bool,
+}

--- a/test
+++ b/test
@@ -11,6 +11,8 @@ cargo test --benches
 echo "==> no_std"
 cargo build -p ab_glyph_rasterizer --target thumbv6m-none-eabi --no-default-features --features libm
 cargo build -p ab_glyph --target thumbv6m-none-eabi --no-default-features --features libm
+echo "==> no_std (variable-fonts)"
+cargo build -p ab_glyph --target thumbv6m-none-eabi --no-default-features --features "libm variable-fonts"
 echo "==> check wasm32"
 cargo build -p ab_glyph_rasterizer --target wasm32-unknown-unknown
 cargo build -p ab_glyph --target wasm32-unknown-unknown


### PR DESCRIPTION
Provides `variations` & `set_variation` functions.

Requires _owned_ttf_parser_ `0.15.2`.

Resolves #61 