### PR TITLE
Do SIMD runtime detection once using `std::sync::Once`

### DIFF
--- a/rasterizer/CHANGELOG.md
+++ b/rasterizer/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased (0.1.8)
+* Do SIMD runtime detection only once on the first `Rasterizer::new` instead of on each.
+
 # 0.1.7
 * Fix x86, x86_64 no_std builds, require `std` feature for runtime detected SIMD.
 


### PR DESCRIPTION
Runtime detection is currently done on each  `Rasterizer::new` construction (which is better than each draw_line call). Since _ab_glyph_rasterizer_ has no dependencies it's undesirable to add _once_cell_ to make this a one time only runtime check.

However, this pr uses `std::sync::Once` to do the runtime detection once without any additional dependencies (std was already required for the runtime-detection).