### PR TITLE
Add width and height info to GlyphImage

### DIFF
--- a/glyph/CHANGELOG.md
+++ b/glyph/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Unreleased (0.2.22)
 * Improve `OutlinedGlyph::draw` documentation.
+* Breaking: Add `width` and `height` fields to `GlyphImage`.
 
 # 0.2.21
 * Update _ttf-parser_ to `0.19`.
 * Add `GlyphImageFormat` variants `BitmapMono`, `BitmapMonoPacked`, `BitmapGray2`, `BitmapGray2Packed`,
   `BitmapGray4`, `BitmapGray4Packed`, `BitmapGray8`, `BitmapPremulBgra32`.
 * `Font::h_advance_unscaled`, `h_side_bearing_unscaled`, `v_advance_unscaled`, `v_side_bearing_unscaled`
-  and related `ScaleFont` methods now return `0.0` if the font does not define that value. 
+  and related `ScaleFont` methods now return `0.0` if the font does not define that value.
   Previously calls would panic when fonts lacked support.
 * Use edition 2021.
 
@@ -40,7 +41,7 @@
 # 0.2.12
 * Update _owned-ttf-parser_ to `0.13.2`.
 * Pre-parse cmap & kern subtables on all `Font` variants at initialization. This provides
-  much faster `glyph_id` & `kern` method performance, results in 25-30% faster layout 
+  much faster `glyph_id` & `kern` method performance, results in 25-30% faster layout
   benchmark performance.
 
 # 0.2.11
@@ -84,7 +85,7 @@
 # 0.2
 * Add `_unscaled` suffix to  `Font` trait methods that deal with unscaled metrics.
   This helps distinguish `ScaleFont`'s scaled metrics and can avoid unintended behaviour.
-* Rename "libm-math" -> "libm" for consistency with _ab_glyph_rasterizer_. 
+* Rename "libm-math" -> "libm" for consistency with _ab_glyph_rasterizer_.
 
 # 0.1
 * Implement fast glyph layout, outline & drawing primitives.

--- a/glyph/src/ttfp.rs
+++ b/glyph/src/ttfp.rs
@@ -20,13 +20,24 @@ impl From<GlyphId> for ttfp::GlyphId {
 /// A pre-rendered image of a glyph, usually used for emojis or other glyphs
 /// that can't be represented only using an outline.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct GlyphImage<'a> {
     /// Offset of the image from the normal origin (top at the baseline plus
     /// ascent), measured in pixels at the image's current scale.
     pub origin: Point,
+    /// Image width.
+    ///
+    /// It doesn't guarantee that this value is the same as set in the `data` in the case of
+    /// [`GlyphImageFormat::Png`] format.
+    pub width: usize,
+    /// Image height.
+    ///
+    /// It doesn't guarantee that this value is the same as set in the `data` in the case of
+    /// [`GlyphImageFormat::Png`] format.
+    pub height: usize,
     /// Current scale of the image in pixels per em.
     pub scale: f32,
-    /// Raw image data (not a bitmap).
+    /// Raw image data, not a bitmap in the case of [`GlyphImageFormat::Png`] format.
     pub data: &'a [u8],
     /// Format of the raw data.
     pub format: GlyphImageFormat,
@@ -36,6 +47,8 @@ impl<'a> From<ttfp::RasterGlyphImage<'a>> for GlyphImage<'a> {
     fn from(img: ttfp::RasterGlyphImage<'a>) -> Self {
         GlyphImage {
             origin: point(img.x.into(), img.y.into()),
+            width: img.width.into(),
+            height: img.height.into(),
             scale: img.pixels_per_em.into(),
             data: img.data,
             format: match img.format {


### PR DESCRIPTION
This is breaking as it adds 2 new struct fields.

Also improved the doc of data field.

A non-breaking approach could be add a new struct `GlyphImage2` whose information are exposed via accessor methods thus can be extended as needed. edit: I would go this way.