### PR TITLE
Add GlyphImage2 to expose width and height info in non-breaking way

### DIFF
--- a/glyph/CHANGELOG.md
+++ b/glyph/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Unreleased (0.2.22)
 * Improve `OutlinedGlyph::draw` documentation.
+* Add `GlyphImage2` and `Font::glyph_raster_image2` to expose width and height info. Also deprecate
+  `GlyphImage2` and `GlyphImage`.
 
 # 0.2.21
 * Update _ttf-parser_ to `0.19`.
 * Add `GlyphImageFormat` variants `BitmapMono`, `BitmapMonoPacked`, `BitmapGray2`, `BitmapGray2Packed`,
   `BitmapGray4`, `BitmapGray4Packed`, `BitmapGray8`, `BitmapPremulBgra32`.
 * `Font::h_advance_unscaled`, `h_side_bearing_unscaled`, `v_advance_unscaled`, `v_side_bearing_unscaled`
-  and related `ScaleFont` methods now return `0.0` if the font does not define that value. 
+  and related `ScaleFont` methods now return `0.0` if the font does not define that value.
   Previously calls would panic when fonts lacked support.
 * Use edition 2021.
 
@@ -40,7 +42,7 @@
 # 0.2.12
 * Update _owned-ttf-parser_ to `0.13.2`.
 * Pre-parse cmap & kern subtables on all `Font` variants at initialization. This provides
-  much faster `glyph_id` & `kern` method performance, results in 25-30% faster layout 
+  much faster `glyph_id` & `kern` method performance, results in 25-30% faster layout
   benchmark performance.
 
 # 0.2.11
@@ -84,7 +86,7 @@
 # 0.2
 * Add `_unscaled` suffix to  `Font` trait methods that deal with unscaled metrics.
   This helps distinguish `ScaleFont`'s scaled metrics and can avoid unintended behaviour.
-* Rename "libm-math" -> "libm" for consistency with _ab_glyph_rasterizer_. 
+* Rename "libm-math" -> "libm" for consistency with _ab_glyph_rasterizer_.
 
 # 0.1
 * Implement fast glyph layout, outline & drawing primitives.

--- a/glyph/src/font.rs
+++ b/glyph/src/font.rs
@@ -1,6 +1,7 @@
+#[allow(deprecated)]
 use crate::{
-    point, Glyph, GlyphId, GlyphImage, Outline, OutlinedGlyph, PxScale, PxScaleFont, Rect,
-    ScaleFont,
+    point, Glyph, GlyphId, GlyphImage, GlyphImage2, Outline, OutlinedGlyph, PxScale, PxScaleFont,
+    Rect, ScaleFont,
 };
 
 /// Functionality required from font data.
@@ -154,7 +155,21 @@ pub trait Font {
     /// used to select between multiple possible images (if present); the returned image will
     /// likely not match this value, requiring you to scale it to match the target resolution.
     /// To get the largest image use `u16::MAX`.
+    #[allow(deprecated)]
+    #[deprecated(
+        since = "0.2.22",
+        note = "Deprecated in favor of `glyph_raster_image2`"
+    )]
     fn glyph_raster_image(&self, id: GlyphId, pixel_size: u16) -> Option<GlyphImage>;
+
+    /// Returns a pre-rendered image of the glyph.
+    ///
+    /// This is normally only present when an outline is not sufficient to describe the glyph, such
+    /// as emojis (particularly color ones).  The `pixel_size` parameter is in pixels per em, and will be
+    /// used to select between multiple possible images (if present); the returned image will
+    /// likely not match this value, requiring you to scale it to match the target resolution.
+    /// To get the largest image use `u16::MAX`.
+    fn glyph_raster_image2(&self, id: GlyphId, pixel_size: u16) -> Option<GlyphImage2>;
 
     /// Returns the layout bounds of this glyph. These are different to the outline `px_bounds()`.
     ///
@@ -291,7 +306,13 @@ impl<F: Font> Font for &F {
     }
 
     #[inline]
+    #[allow(deprecated)]
     fn glyph_raster_image(&self, id: GlyphId, size: u16) -> Option<GlyphImage> {
         (*self).glyph_raster_image(id, size)
+    }
+
+    #[inline]
+    fn glyph_raster_image2(&self, id: GlyphId, size: u16) -> Option<GlyphImage2> {
+        (*self).glyph_raster_image2(id, size)
     }
 }

--- a/glyph/src/font_arc.rs
+++ b/glyph/src/font_arc.rs
@@ -1,4 +1,5 @@
-use crate::{Font, FontRef, FontVec, GlyphId, GlyphImage, InvalidFont, Outline};
+#[allow(deprecated)]
+use crate::{Font, FontRef, FontVec, GlyphId, GlyphImage, GlyphImage2, InvalidFont, Outline};
 use alloc::sync::Arc;
 use core::fmt;
 
@@ -137,8 +138,13 @@ impl Font for FontArc {
     }
 
     #[inline]
+    #[allow(deprecated)]
     fn glyph_raster_image(&self, id: GlyphId, size: u16) -> Option<GlyphImage> {
         self.0.glyph_raster_image(id, size)
+    }
+
+    fn glyph_raster_image2(&self, id: GlyphId, size: u16) -> Option<GlyphImage2> {
+        self.0.glyph_raster_image2(id, size)
     }
 }
 

--- a/glyph/src/lib.rs
+++ b/glyph/src/lib.rs
@@ -39,6 +39,7 @@ mod variable;
 
 #[cfg(feature = "std")]
 pub use crate::font_arc::*;
+#[allow(deprecated)]
 pub use crate::{
     codepoint_ids::*,
     err::*,
@@ -46,7 +47,7 @@ pub use crate::{
     glyph::*,
     outlined::*,
     scale::*,
-    ttfp::{FontRef, FontVec, GlyphImage, GlyphImageFormat},
+    ttfp::{FontRef, FontVec, GlyphImage, GlyphImage2, GlyphImageFormat},
 };
 #[cfg(feature = "variable-fonts")]
 pub use variable::*;


### PR DESCRIPTION
All fields of `GlyphImage2` are private and are exposed via accessor methods to allow future additions.

Also add a `glyph_raster_image2` method to `Font` trait to get a `GlyphImage2`, the default implementation is filled with an `unimplemented!()` to make it non-breaking.

In turn `GlyphImage` and `<Font>::glyph_raster_image` are marked as deprecated.

---

This is alternative approach to #87.