### PR TITLE
adding `neutral` function to `PxScale`

### DIFF
--- a/glyph/src/scale.rs
+++ b/glyph/src/scale.rs
@@ -36,6 +36,15 @@ impl PxScale {
             y: self.y.round(),
         }
     }
+
+    /// Returns a `PxScale` with `x = 1.0 = y` so that it does nothing (= is neutral) when trying to scale pixels.
+    #[inline]
+    pub fn neutral() -> Self {
+        Self {
+            x: 1.0,
+            y: 1.0,
+        }
+    }
 }
 
 impl From<f32> for PxScale {


### PR DESCRIPTION
I think that this might be useful. But I can also understand if it's not. (just a suggestion).