### PR TITLE
Add impl for Clone trait for FontVec

### DIFF
--- a/glyph/src/ttfp.rs
+++ b/glyph/src/ttfp.rs
@@ -104,6 +104,12 @@ impl fmt::Debug for FontVec {
     }
 }
 
+impl Clone for FontVec {
+    fn clone(&self) -> Self {
+        Self::try_from_vec(self.as_slice().to_vec()).unwrap()
+    }
+}
+
 impl FontVec {
     /// Creates an `FontVec` from owned data.
     ///


### PR DESCRIPTION
This implements `Clone` trait for `FontVec`.

It is just a small change,
but it can co-operate with a lot of Rust's generic mechanism (e.g. `impl<T, A> Clone for Vec<T, A>`),
and are good for convienience (e.g. now we can `vec_of_fontvecs.clone()`).
