### PR TITLE
Fix `draw_line_scalar` index oob panic scenario

### DIFF
--- a/rasterizer/CHANGELOG.md
+++ b/rasterizer/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased (0.1.9)
-* Use edition 2021.
+* Fix `draw_line_scalar` index oob panic scenario (2).
 
 # 0.1.8
 * Do SIMD runtime detection only once on the first `Rasterizer::new` instead of on each.
@@ -18,7 +18,7 @@
 * Add `Rasterizer::reset`, `Rasterizer::clear` methods to allow allocation reuse.
 
 # 0.1.3
-* Fix index oob panic scenario.
+* Fix `draw_line_scalar` index oob panic scenario.
 
 # 0.1.2
 * For `Point` implement `Sub`, `Add`, `SubAssign`, `AddAssign`, `PartialEq`, `PartialOrd`, `From<(x, y)>`,

--- a/rasterizer/src/raster.rs
+++ b/rasterizer/src/raster.rs
@@ -131,7 +131,7 @@ impl Rasterizer {
             if x1i <= x0i + 1 {
                 let xmf = 0.5 * (x + xnext) - x0floor;
                 let linestart_x0i = linestart as isize + x0i as isize;
-                if linestart_x0i < 0 {
+                if linestart_x0i < 0 || linestart_x0i as usize + 1 >= self.a.len() {
                     continue; // oob index
                 }
                 self.a[linestart_x0i as usize] += d - d * xmf;
@@ -143,7 +143,7 @@ impl Rasterizer {
                 let x1f = x1 - x1ceil + 1.0;
                 let am = 0.5 * s * x1f * x1f;
                 let linestart_x0i = linestart as isize + x0i as isize;
-                if linestart_x0i < 0 {
+                if linestart_x0i < 0 || linestart_x0i as usize + 1 >= self.a.len() {
                     continue; // oob index
                 }
                 self.a[linestart_x0i as usize] += d * a0;


### PR DESCRIPTION
This seems somewhat similar to https://github.com/alexheretic/ab-glyph/pull/21 though lacks a reproducer test as that did. Even without a solid reproducer checking both bounds seems reasonable if we're checking one.

Resolves #115 