### PR TITLE
Add `FontArc` support for no_std targets with cfg(target_has_atomic = "ptr")

### DIFF
--- a/glyph/CHANGELOG.md
+++ b/glyph/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased (0.2.32)
+* Add `FontArc` support for no_std targets with cfg(target_has_atomic = "ptr").
+
 # 0.2.31
 * Add "gvar-alloc" feature enabled by default (activates _ttf-parser_ "gvar-alloc" feature).
   Provides full gvar table support.

--- a/glyph/src/font_arc.rs
+++ b/glyph/src/font_arc.rs
@@ -1,5 +1,7 @@
 use crate::{v2, Font, FontRef, FontVec, GlyphId, InvalidFont, Outline};
 use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use core::fmt;
 
 /// `Font` implementor that wraps another concrete `Font + 'static` type storing in an `Arc`.

--- a/glyph/src/lib.rs
+++ b/glyph/src/lib.rs
@@ -26,7 +26,7 @@ extern crate alloc;
 mod codepoint_ids;
 mod err;
 mod font;
-#[cfg(feature = "std")]
+#[cfg(target_has_atomic = "ptr")]
 mod font_arc;
 mod glyph;
 #[cfg(all(feature = "libm", not(feature = "std")))]
@@ -37,7 +37,7 @@ mod ttfp;
 #[cfg(feature = "variable-fonts")]
 mod variable;
 
-#[cfg(feature = "std")]
+#[cfg(target_has_atomic = "ptr")]
 pub use crate::font_arc::*;
 #[allow(deprecated)]
 pub use crate::{

--- a/test
+++ b/test
@@ -11,6 +11,8 @@ cargo test --benches
 echo "==> no_std"
 cargo build -p ab_glyph_rasterizer --target thumbv6m-none-eabi --no-default-features --features libm
 cargo build -p ab_glyph --target thumbv6m-none-eabi --no-default-features --features libm
+cargo build -p ab_glyph_rasterizer --no-default-features --features libm
+cargo build -p ab_glyph --no-default-features --features libm
 echo "==> no_std (variable-fonts)"
 cargo build -p ab_glyph --target thumbv6m-none-eabi --no-default-features --features "libm variable-fonts"
 echo "==> check wasm32"


### PR DESCRIPTION
Resolves #123 